### PR TITLE
Add tokenizeCard to plugin

### DIFF
--- a/src/ios/CDVCardFlight.m
+++ b/src/ios/CDVCardFlight.m
@@ -19,6 +19,7 @@
 @property (nonatomic) NSString *onEMVCardDippedCallbackId;
 @property (nonatomic) NSString *onEMVCardRemovedCallbackId;
 @property (nonatomic) NSString *onTransactionResultCallbackId;
+@property (nonatomic) NSString *onTokenizeCardCallbackId;
 @end
 
 @implementation CDVCardFlight
@@ -393,6 +394,25 @@
 }
 
 
+// Tokenize a card
+// Sends plugin data via onTokenizeCardCallbackId
+
+- (void)tokenizeCardWithSuccess:(CDVInvokedUrlCommand *)command {
+    __weak CDVCardFlight *weakSelf = self;
+
+    [_card tokenizeCardWithSuccess:^{
+        NSLog(@"Token received %@", _card.cardToken);
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:_card.cardToken];
+        [result setKeepCallbackAsBool:TRUE];
+        [weakSelf.commandDelegate sendPluginResult:result callbackId:weakSelf.onTokenizeCardCallbackId];
+    } failure:^(NSError *error) {
+        NSLog(@"%@", error.localizedDescription);
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
+        [result setKeepCallbackAsBool:TRUE];
+        [weakSelf.commandDelegate sendPluginResult:result callbackId:weakSelf.onTokenizeCardCallbackId];
+    }];
+}
+
 // Server response after submitting data
 
 -(void)serverResponse:(NSData *)response andError:(NSError *)error {
@@ -585,6 +605,13 @@
     NSLog(@"set onTransactionResultCallbackId");
 }
 
+// Set callback ID to be a listener, reusable by the plugin.
+// After this is set, onTokenizeCard will send results to onTokenizeCardCallbackId
+
+- (void)registerOnTokenizeCard:(CDVInvokedUrlCommand*)command {
+    self.onTokenizeCardCallbackId = command.callbackId;
+    NSLog(@"set onTokenizeCardCallbackId");
+}
 
 // Set callback ID to be a listener, reusable by the plugin.
 // After this is set, onLowBattery will send results to onLowBatteryCallbackId

--- a/src/ios/CFTReader.h
+++ b/src/ios/CFTReader.h
@@ -230,6 +230,9 @@
  */
 - (void)beginSwipe;
 
+- (void)tokenizeCardWithSuccess:(void(^)(void))success
+          failure:(void(^)(NSError *error))failure;
+
 /*!
  * @brief Set the reader to auto timeout after 20 seconds
  * @param hasTimeout BOOL to set timeout on or off
@@ -297,7 +300,7 @@
 /*!
  * @brief Select the application in a multy AID transaction
  * @param application Index of the application selected
- * @discussion Set the application to be used for an EMV transaction. 
+ * @discussion Set the application to be used for an EMV transaction.
  * Used in conjunction with emvApplicationSelection protocol method.
  * Added in 3.0
  */

--- a/www/CDVCardFlight.js
+++ b/www/CDVCardFlight.js
@@ -107,6 +107,12 @@ CardFlight.prototype.uploadSignature = function(successCallback, errorCallback, 
   exec(successCallback, errorCallback, "CDVCardFlight", "uploadSignature", [options]);
 };
 
+// Tokenize a card
+// Result will be sent through registerOnTokenizeCard callbacks.
+CardFlight.prototype.tokenizeCard = function(successCallback, errorCallback) {
+  exec(successCallback, errorCallback, "CDVCardFlight", "tokenizeCardWithSuccess", []);
+};
+
 // Set callback ID to be a listener, reusable by the plugin.
 // After this is set, onCardSwiped will send results to the callbacks passed here.
 CardFlight.prototype.registerOnCardSwiped = function(successCallback, errorCallback) {
@@ -183,6 +189,12 @@ CardFlight.prototype.registerOnTransactionResult = function(successCallback, err
 // After this is set, onLowBattery will send results to the callbacks passed here.
 CardFlight.prototype.registerOnLowBattery = function(successCallback, errorCallback, options) {
   exec(successCallback, errorCallback, "CDVCardFlight", "registerOnLowBattery", []);
+};
+
+// Set callback ID to be a listener, reusable by the plugin.
+// After this is set, onTokenizeCard will send results to the callbacks passed here.
+CardFlight.prototype.registerOnTokenizeCard = function(successCallback, errorCallback) {
+  exec(successCallback, errorCallback, "CDVCardFlight", "registerOnTokenizeCard", []);
 };
 
 module.exports = new CardFlight();


### PR DESCRIPTION
This allows us to tokenize the card on stripe.  Currently we are doing this by registering a new kind of callback listener.  Curious if there may be a better way (e.g., maybe the `tokenizeCard` function could get the token directly in the callback).
